### PR TITLE
session4 mixin

### DIFF
--- a/lib/green_widget.dart
+++ b/lib/green_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_training/main_view.dart';
+import 'package:flutter_training/on_appear_mixin.dart';
 
 class GreenWidget extends StatefulWidget {
   const GreenWidget({super.key});
@@ -9,14 +10,9 @@ class GreenWidget extends StatefulWidget {
   State<GreenWidget> createState() => _GreenWidgetState();
 }
 
-class _GreenWidgetState extends State<GreenWidget> {
+class _GreenWidgetState extends State<GreenWidget> with OnAppearMixin {
   @override
-  void initState() {
-    super.initState();
-    unawaited(_navigateToMainWidget());
-  }
-
-  Future<void> _navigateToMainWidget() async {
+  Future<void> actionOnAppear() async {
     // 500ミリ秒遅延させる
     await Future<void>.delayed(const Duration(milliseconds: 500));
 
@@ -33,8 +29,8 @@ class _GreenWidgetState extends State<GreenWidget> {
       ),
     );
 
-    // 再度 `_navigateToMainWidget` を呼び出す
-    await _navigateToMainWidget();
+    // 再起的に呼び出す
+    await actionOnAppear();
   }
 
   @override

--- a/lib/on_appear_mixin.dart
+++ b/lib/on_appear_mixin.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+mixin OnAppearMixin<T extends StatefulWidget> on State<T> {
+  Future<void> actionOnAppear();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await actionOnAppear();
+    });
+  }
+}


### PR DESCRIPTION
## 課題

close #5

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] レイアウトが表示された後に「何かしらの処理」を行う [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を作成する
- [x] 作成した [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) の使用先で「何かしらの処理」を記述できるようにする
- [x] [Session3](https://github.com/Kota1021/FlutterTraining/issues/4) で作成した以下の処理を作成した [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を使って書き直す
  新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->
<img src='https://github.com/Kota1021/FlutterTraining/assets/9388824/45fb9da6-e8a5-4eaf-a899-b17c027ce68b' width=200> 
