### PR TITLE
session5 error handling

### DIFF
--- a/lib/green_widget.dart
+++ b/lib/green_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_training/main_view.dart';
+import 'package:flutter_training/on_appear_mixin.dart';
 
 class GreenWidget extends StatefulWidget {
   const GreenWidget({super.key});
@@ -9,14 +10,9 @@ class GreenWidget extends StatefulWidget {
   State<GreenWidget> createState() => _GreenWidgetState();
 }
 
-class _GreenWidgetState extends State<GreenWidget> {
+class _GreenWidgetState extends State<GreenWidget> with OnAppearMixin {
   @override
-  void initState() {
-    super.initState();
-    unawaited(_navigateToMainWidget());
-  }
-
-  Future<void> _navigateToMainWidget() async {
+  Future<void> actionOnAppear() async {
     // 500ミリ秒遅延させる
     await Future<void>.delayed(const Duration(milliseconds: 500));
 
@@ -33,8 +29,8 @@ class _GreenWidgetState extends State<GreenWidget> {
       ),
     );
 
-    // 再度 `_navigateToMainWidget` を呼び出す
-    await _navigateToMainWidget();
+    // 再起的に呼び出す
+    await actionOnAppear();
   }
 
   @override

--- a/lib/main_view.dart
+++ b/lib/main_view.dart
@@ -15,6 +15,22 @@ class _MainViewState extends State<MainView> {
   final yumemiWeather = YumemiWeather();
   WeatherKind? weatherKind;
 
+  Future<void> showErrorDialog(YumemiWeatherError error) async {
+    await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('天気の取得に失敗'),
+        content: Text('error name: ${error.name}'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'OK'),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final labelLargeStyle = Theme.of(context).textTheme.labelLarge;
@@ -51,13 +67,17 @@ class _MainViewState extends State<MainView> {
                       ),
                       Expanded(
                         child: TextButton(
-                          onPressed: () {
-                            final weatherStr =
-                                yumemiWeather.fetchSimpleWeather();
-                            setState(() {
-                              weatherKind =
-                                  WeatherKind.values.byName(weatherStr);
-                            });
+                          onPressed: () async {
+                            try {
+                              final weatherStr =
+                                  yumemiWeather.fetchThrowsWeather('tokyo');
+                              setState(() {
+                                weatherKind =
+                                    WeatherKind.values.byName(weatherStr);
+                              });
+                            } on YumemiWeatherError catch (e) {
+                              await showErrorDialog(e);
+                            }
                           },
                           child: Text(
                             'Reload',

--- a/lib/on_appear_mixin.dart
+++ b/lib/on_appear_mixin.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+mixin OnAppearMixin<T extends StatefulWidget> on State<T> {
+  Future<void> actionOnAppear();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await actionOnAppear();
+    });
+  }
+}


### PR DESCRIPTION
## 課題

close #6

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて AlertDialog でメッセージを表示する
- [x] メッセージの内容は自由
     AlertDialog の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

<img src='https://github.com/Kota1021/FlutterTraining/assets/9388824/e5827be0-5d61-44cb-bfd9-9434c31ced18' width=200> 

